### PR TITLE
Add organization creation functionality (backend and frontend)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -57,6 +57,10 @@
 			<version>4.13.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>app</finalName>

--- a/backend/src/main/java/de/neuefische/backend/controller/OrganizationController.java
+++ b/backend/src/main/java/de/neuefische/backend/controller/OrganizationController.java
@@ -1,12 +1,11 @@
 package de.neuefische.backend.controller;
 
 import de.neuefische.backend.model.Organization;
+import de.neuefische.backend.model.OrganizationDTO;
 import de.neuefische.backend.service.OrganizationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,6 +19,11 @@ public class OrganizationController {
     @GetMapping
     public List<Organization> getAllOrganizations() {
         return organizationService.getAllOrganizations();
+    }
 
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public Organization addOrganization(@RequestBody OrganizationDTO organizationDTO) {
+        return organizationService.save(organizationDTO);
     }
 }

--- a/backend/src/main/java/de/neuefische/backend/controller/OrganizationController.java
+++ b/backend/src/main/java/de/neuefische/backend/controller/OrganizationController.java
@@ -3,6 +3,7 @@ package de.neuefische.backend.controller;
 import de.neuefische.backend.model.Organization;
 import de.neuefische.backend.model.OrganizationDTO;
 import de.neuefische.backend.service.OrganizationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +24,7 @@ public class OrganizationController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public Organization addOrganization(@RequestBody OrganizationDTO organizationDTO) {
+    public Organization addOrganization(@Valid @RequestBody OrganizationDTO organizationDTO) {
         return organizationService.save(organizationDTO);
     }
 }

--- a/backend/src/main/java/de/neuefische/backend/controller/OrganizationController.java
+++ b/backend/src/main/java/de/neuefische/backend/controller/OrganizationController.java
@@ -25,6 +25,6 @@ public class OrganizationController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public Organization addOrganization(@Valid @RequestBody OrganizationDTO organizationDTO) {
-        return organizationService.save(organizationDTO);
+        return organizationService.saveOrganizationFromDTO(organizationDTO);
     }
 }

--- a/backend/src/main/java/de/neuefische/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/de/neuefische/backend/exception/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package de.neuefische.backend.exception;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
 
 
 @RestControllerAdvice
@@ -14,5 +17,21 @@ public class GlobalExceptionHandler {
     public ErrorMessage handleException(Exception exception) {
         return new ErrorMessage("An unexpected error occurred: " + exception.getMessage());
     }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorMessage handleValidationExceptions(MethodArgumentNotValidException exception) {
+
+        List<String> errorMessages = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .toList();
+
+        String errorMessage = String.join(", ", errorMessages);
+
+        return new ErrorMessage("Validation failed: " + errorMessage);
+    }
+
 
 }

--- a/backend/src/main/java/de/neuefische/backend/model/Organization.java
+++ b/backend/src/main/java/de/neuefische/backend/model/Organization.java
@@ -1,7 +1,8 @@
 package de.neuefische.backend.model;
 
+
 public record Organization(
-        int id,
+        String id,
         String name,
         String homepage
 ) {

--- a/backend/src/main/java/de/neuefische/backend/model/OrganizationDTO.java
+++ b/backend/src/main/java/de/neuefische/backend/model/OrganizationDTO.java
@@ -1,0 +1,8 @@
+package de.neuefische.backend.model;
+
+
+public record OrganizationDTO(
+        String name,
+        String homepage
+) {
+}

--- a/backend/src/main/java/de/neuefische/backend/model/OrganizationDTO.java
+++ b/backend/src/main/java/de/neuefische/backend/model/OrganizationDTO.java
@@ -1,7 +1,9 @@
 package de.neuefische.backend.model;
 
+import jakarta.validation.constraints.NotNull;
 
 public record OrganizationDTO(
+        @NotNull(message = "Name is mandatory")
         String name,
         String homepage
 ) {

--- a/backend/src/main/java/de/neuefische/backend/service/IdService.java
+++ b/backend/src/main/java/de/neuefische/backend/service/IdService.java
@@ -1,0 +1,12 @@
+package de.neuefische.backend.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class IdService {
+    public String generateRandomId() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/backend/src/main/java/de/neuefische/backend/service/OrganizationService.java
+++ b/backend/src/main/java/de/neuefische/backend/service/OrganizationService.java
@@ -19,7 +19,7 @@ public class OrganizationService {
         return organizationRepo.findAll();
     }
 
-    public Organization save(OrganizationDTO organizationDTO) {
+    public Organization saveOrganizationFromDTO(OrganizationDTO organizationDTO) {
         Organization organization = new Organization(
                 idService.generateRandomId(),
                 organizationDTO.name(), organizationDTO.homepage());

--- a/backend/src/main/java/de/neuefische/backend/service/OrganizationService.java
+++ b/backend/src/main/java/de/neuefische/backend/service/OrganizationService.java
@@ -1,6 +1,7 @@
 package de.neuefische.backend.service;
 
 import de.neuefische.backend.model.Organization;
+import de.neuefische.backend.model.OrganizationDTO;
 import de.neuefische.backend.repository.OrganizationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,7 +13,16 @@ import java.util.List;
 public class OrganizationService {
 
     private final OrganizationRepository organizationRepo;
+    private final IdService idService;
 
-    public List<Organization> getAllOrganizations () {
-    return organizationRepo.findAll();}
+    public List<Organization> getAllOrganizations() {
+        return organizationRepo.findAll();
+    }
+
+    public Organization save(OrganizationDTO organizationDTO) {
+        Organization organization = new Organization(
+                idService.generateRandomId(),
+                organizationDTO.name(), organizationDTO.homepage());
+        return organizationRepo.save(organization);
+    }
 }

--- a/backend/src/test/java/de/neuefische/backend/controller/OrganizationControllerIntegrationTest.java
+++ b/backend/src/test/java/de/neuefische/backend/controller/OrganizationControllerIntegrationTest.java
@@ -2,13 +2,18 @@ package de.neuefische.backend.controller;
 
 import de.neuefische.backend.model.Organization;
 import de.neuefische.backend.repository.OrganizationRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -20,20 +25,24 @@ class OrganizationControllerIntegrationTest {
     @Autowired
     OrganizationRepository organizationRepository;
 
+    @BeforeEach
+    void setUp() {
+        organizationRepository.deleteAll();
+    }
+
     @Test
     void getAllOrganizations_shouldReturnListOfOrganizations() throws Exception {
         Organization organization = new Organization("1", "testname", "testhomepage");
         organizationRepository.save(organization);
         mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().json(
+                .andExpect(content().json(
                         """
                                 [
                                 {
                                   "id": "1",
                                   "name": "testname",
                                   "homepage": "testhomepage"
-                                
                                 }
                                 ]
                                 """
@@ -41,12 +50,45 @@ class OrganizationControllerIntegrationTest {
     }
 
     @Test
-    void shouldReturnEmptyListIntegrationTest() throws Exception {
-        organizationRepository.deleteAll();
+    void getAllOrganizations_shouldReturnEmptyListIntegrationTest() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().string("[]"));
+                .andExpect(content().string("[]"));
     }
 
+
+    @Test
+    void addOrganization_shouldSaveOrganizationWithId() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/organizations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                "name": "testorganization",
+                                "homepage": "testhomepage"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(content().json(
+                        """
+                                {
+                                "name": "testorganization",
+                                "homepage": "testhomepage"
+                                }
+                                """
+                )).andExpect(jsonPath("$.id").isNotEmpty());
+
+    }
+
+    @Test
+    void addOrganization_returnBadRequest_whenOrganizationNameMissing() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/organizations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                "homepage": "testhomepage"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
 
 }

--- a/backend/src/test/java/de/neuefische/backend/controller/OrganizationControllerIntegrationTest.java
+++ b/backend/src/test/java/de/neuefische/backend/controller/OrganizationControllerIntegrationTest.java
@@ -22,7 +22,7 @@ class OrganizationControllerIntegrationTest {
 
     @Test
     void getAllOrganizations_shouldReturnListOfOrganizations() throws Exception {
-        Organization organization = new Organization(1, "testname", "testhomepage");
+        Organization organization = new Organization("1", "testname", "testhomepage");
         organizationRepository.save(organization);
         mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -30,7 +30,7 @@ class OrganizationControllerIntegrationTest {
                         """
                                 [
                                 {
-                                  "id": 1,
+                                  "id": "1",
                                   "name": "testname",
                                   "homepage": "testhomepage"
                                 

--- a/backend/src/test/java/de/neuefische/backend/service/IdServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/IdServiceTest.java
@@ -1,0 +1,23 @@
+package de.neuefische.backend.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IdServiceTest {
+    private final IdService idService = new IdService();
+
+    @Test
+    void generateRandomId_shouldReturnValidUUID() {
+        String generatedId = idService.generateRandomId();
+        assertTrue(generatedId.matches("^[a-f0-9-]{36}$"));
+    }
+
+    @Test
+    void generateRandomId_shouldGenerateUniqueIds() {
+        String id1 = idService.generateRandomId();
+        String id2 = idService.generateRandomId();
+        assertNotEquals(id1, id2);
+    }
+}

--- a/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
@@ -26,8 +26,8 @@ class OrganizationServiceTest {
 
     @Test
     void getAllOrganizations_shouldReturnAllInputOrganizations() {
-        Organization organization1 = new Organization(1, "testname1", "testhomepage1");
-        Organization organization2 = new Organization(1, "testname2", "testhomepage2");
+        Organization organization1 = new Organization("1", "testname1", "testhomepage1");
+        Organization organization2 = new Organization("2", "testname2", "testhomepage2");
         List<Organization> expected = new ArrayList<>(List.of(organization1, organization2));
         when(organizationRepository.findAll()).thenReturn(expected);
         List<Organization> actual = organizationService.getAllOrganizations();

--- a/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
@@ -13,7 +13,8 @@ import static org.mockito.Mockito.*;
 class OrganizationServiceTest {
 
     OrganizationRepository organizationRepository = mock(OrganizationRepository.class);
-    OrganizationService organizationService = new OrganizationService(organizationRepository);
+    IdService idService = new IdService();
+    OrganizationService organizationService = new OrganizationService(organizationRepository, idService);
 
     @Test
     void getAllOrganizations_returnsEmptyList_whenRepositoryIsEmpty() {

--- a/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
@@ -1,6 +1,7 @@
 package de.neuefische.backend.service;
 
 import de.neuefische.backend.model.Organization;
+import de.neuefische.backend.model.OrganizationDTO;
 import de.neuefische.backend.repository.OrganizationRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -12,16 +13,16 @@ import static org.mockito.Mockito.*;
 
 class OrganizationServiceTest {
 
-    OrganizationRepository organizationRepository = mock(OrganizationRepository.class);
-    IdService idService = new IdService();
-    OrganizationService organizationService = new OrganizationService(organizationRepository, idService);
+    OrganizationRepository mockedOrganisationRepo = mock(OrganizationRepository.class);
+    IdService mockedIdService = mock(IdService.class);
+    OrganizationService organizationService = new OrganizationService(mockedOrganisationRepo, mockedIdService);
 
     @Test
     void getAllOrganizations_returnsEmptyList_whenRepositoryIsEmpty() {
         List<Organization> expected = List.of();
-        when(organizationRepository.findAll()).thenReturn((List.of()));
+        when(mockedOrganisationRepo.findAll()).thenReturn((List.of()));
         List<Organization> actual = organizationService.getAllOrganizations();
-        verify(organizationRepository).findAll();
+        verify(mockedOrganisationRepo).findAll();
         Assertions.assertEquals(expected, actual);
     }
 
@@ -30,9 +31,31 @@ class OrganizationServiceTest {
         Organization organization1 = new Organization("1", "testname1", "testhomepage1");
         Organization organization2 = new Organization("2", "testname2", "testhomepage2");
         List<Organization> expected = new ArrayList<>(List.of(organization1, organization2));
-        when(organizationRepository.findAll()).thenReturn(expected);
+        when(mockedOrganisationRepo.findAll()).thenReturn(expected);
         List<Organization> actual = organizationService.getAllOrganizations();
-        verify(organizationRepository).findAll();
+        verify(mockedOrganisationRepo).findAll();
         Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    void saveOrganizationFromDTO_shouldReturnOrganizationWithGeneratedId() {
+        OrganizationDTO organizationDTO = new OrganizationDTO("testname", "testhomepage");
+        Organization expected = new Organization("123", "testname", "testhomepage");
+        when(mockedOrganisationRepo.save(expected)).thenReturn(expected);
+        when(mockedIdService.generateRandomId()).thenReturn("123");
+
+        Organization organizationActual = organizationService.saveOrganizationFromDTO(organizationDTO);
+        verify(mockedOrganisationRepo).save(expected);
+        verify(mockedIdService).generateRandomId();
+
+        Assertions.assertEquals(expected, organizationActual);
+
+    }
+
+    @Test
+    void saveOrganizationFromDTO_shouldThrowExceptionWhenDTOIsNull() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> organizationService.saveOrganizationFromDTO(null)
+        );
     }
 }

--- a/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
@@ -20,19 +20,18 @@ class OrganizationServiceTest {
         List<Organization> expected = List.of();
         when(organizationRepository.findAll()).thenReturn((List.of()));
         List<Organization> actual = organizationService.getAllOrganizations();
-        Assertions.assertEquals(expected, actual);
         verify(organizationRepository).findAll();
+        Assertions.assertEquals(expected, actual);
     }
 
     @Test
     void getAllOrganizations_shouldReturnAllInputOrganizations() {
         Organization organization1 = new Organization(1, "testname1", "testhomepage1");
         Organization organization2 = new Organization(1, "testname2", "testhomepage2");
-
         List<Organization> expected = new ArrayList<>(List.of(organization1, organization2));
         when(organizationRepository.findAll()).thenReturn(expected);
         List<Organization> actual = organizationService.getAllOrganizations();
-        Assertions.assertEquals(expected, actual);
         verify(organizationRepository).findAll();
+        Assertions.assertEquals(expected, actual);
     }
 }

--- a/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
@@ -52,10 +52,4 @@ class OrganizationServiceTest {
 
     }
 
-    @Test
-    void saveOrganizationFromDTO_shouldThrowExceptionWhenDTOIsNull() {
-        Assertions.assertThrows(NullPointerException.class,
-                () -> organizationService.saveOrganizationFromDTO(null)
-        );
-    }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import {useEffect, useState} from "react";
 import axios from "axios";
 import {Organization} from "./types/Organization.ts";
 import Home from "./components/Home.tsx";
+import Header from "./components/Header.tsx";
+import NewOrganization from "./components/NewOrganization.tsx";
 
 
 function App() {
@@ -24,8 +26,10 @@ function App() {
 
     return (
         <div className="app-container">
+            <Header/>
         <Routes>
             <Route path="/" element={<Home organizations={organizations}/>}/>
+            <Route path="/add-organization" element={<NewOrganization/>}/>
         </Routes>
         </div>
     )

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,19 @@
+import {useNavigate} from "react-router-dom";
+
+
+function Header() {
+
+    const navigate = useNavigate();
+
+    const handleAddOrganization = () => {
+        navigate("/add-organization")
+    }
+
+    return (
+        <div>
+            <button onClick={handleAddOrganization}>Neue Weiterbildungsanbieter</button>
+        </div>
+    );
+}
+
+export default Header;

--- a/frontend/src/components/NewOrganization.tsx
+++ b/frontend/src/components/NewOrganization.tsx
@@ -1,0 +1,56 @@
+import axios from "axios";
+import {useState} from "react";
+import "../styles/NewOrganization.css"
+
+function NewOrganization() {
+    const [name, setName] = useState("");
+    const [homepage, setHomepage] = useState("");
+    const [errorMessage, setErrorMessage] = useState('');
+    const [successMessage, setSuccessMessage] = useState('');
+
+
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        const newOrganization = {name, homepage};
+
+        axios
+            .post('api/organizations', newOrganization)
+            .then((response) => {
+                console.log('Neue Organisation erstellt:', response.data);
+                setName('');
+                setSuccessMessage('Die Organisation wurde erfolgreich hinzugefügt!');
+                setErrorMessage('');
+            })
+            .catch((error) => {
+                console.error('Fehler beim Erstellen der Organisation:', error);
+                setErrorMessage('Fehler beim Hinzufügen der Organisation. Bitte versuche es später erneut.');
+                setSuccessMessage('');
+            });
+    };
+
+    return (
+        <div className="new-organization">
+            <h2>Neuer Weiterbildungsanbieter hinzufügen</h2>
+            <form onSubmit={handleSubmit} className="form">
+                <input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Name der Organisation"
+                    required
+                />
+                <input
+                    type="text"
+                    value={homepage}
+                    onChange={(e) => setHomepage(e.target.value)}
+                    placeholder="Webseite"
+                />
+                <button type="submit">Absenden</button>
+            </form>
+            {successMessage && <p className="success-message">{successMessage}</p>}
+            {errorMessage && <p className="error-message">{errorMessage}</p>}
+        </div>
+    );
+}
+
+export default NewOrganization;

--- a/frontend/src/components/OrganizationCard.tsx
+++ b/frontend/src/components/OrganizationCard.tsx
@@ -12,7 +12,6 @@ function OrganizationCard(props: OrganizationPageProps) {
             <a className="card-homepage" href={props.organization.homepage}>{props.organization.homepage}</a>
         </div>
     )
-        ;
 }
 
 export default OrganizationCard;

--- a/frontend/src/components/OrganizationCard.tsx
+++ b/frontend/src/components/OrganizationCard.tsx
@@ -9,7 +9,8 @@ function OrganizationCard(props: OrganizationPageProps) {
     return (
         <div className="card">
             <h2 className="card-title">{props.organization.name}</h2>
-            <a className="card-homepage" href={props.organization.homepage}>{props.organization.homepage}</a>
+            <a className="card-homepage" target="_blank"
+               href={props.organization.homepage}>{props.organization.homepage}</a>
         </div>
     )
 }

--- a/frontend/src/styles/NewOrganization.css
+++ b/frontend/src/styles/NewOrganization.css
@@ -1,0 +1,47 @@
+/* Beispiel: Nehmen wir an, die allgemeinen Eingabe- und Button-Styles sind so ähnlich wie in deinem allgemeinen Design */
+
+/* Beispielhafte allgemeine Stile für Eingabefelder und Buttons auf der Webseite */
+.form-input {
+    width: 100%;
+    padding: 10px;
+    margin: 10px 0;
+    border: 1px solid #ccc; /* Standard-Grenze, die zu den anderen Feldern auf deiner Seite passt */
+    border-radius: 4px;
+    font-size: 16px; /* Ähnlich der Schriftgröße von anderen Inputs */
+}
+
+.form-button {
+    padding: 10px 15px;
+    background-color: #007bff; /* Blau, wie in einem Standard-Button */
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 16px;
+    cursor: pointer;
+    width: 100%;
+}
+
+.form-button:hover {
+    background-color: #0056b3; /* Etwas dunkleres Blau für Hover-Effekt */
+}
+
+/* Optional: Abstand und Layout */
+.new-organization {
+    max-width: 400px;
+    margin: 0 auto;
+    padding: 20px;
+    background-color: #f9f9f9;
+    border-radius: 8px;
+}
+
+h2 {
+    text-align: center;
+    font-size: 24px;
+    margin-bottom: 20px;
+}
+
+.form {
+    display: flex;
+    flex-direction: column; /* Stellt die Felder untereinander */
+    gap: 15px; /* Abstand zwischen den Feldern */
+}

--- a/frontend/src/types/Organization.ts
+++ b/frontend/src/types/Organization.ts
@@ -1,6 +1,6 @@
 export type Organization =
     {
-        id: number,
+        id: string,
         name: string,
         homepage: string;
     }


### PR DESCRIPTION
Added in backend:

Created OrganizationDTO
Created IdService to generate organization IDs
Organization: changed ID from Integer to String
OrganizationController: Added PostMapping for /api/organizations
OrganizationService: Implemented saveOrganizationFromDTO
GlobalExceptionHandler: Added handleValidationExceptions

Added in frontend:

Header with button to add a new organization
Created NewOrganization component for /add-organization
Styled NewOrganization

Tests:

Unit tests for OrganizationService and IdService
Integration tests for OrganizationController