### PR TITLE
Endpoint: delete organization

### DIFF
--- a/backend/src/main/java/de/neuefische/backend/controller/OrganizationController.java
+++ b/backend/src/main/java/de/neuefische/backend/controller/OrganizationController.java
@@ -37,4 +37,10 @@ public class OrganizationController {
     public Organization updateOrganization(@PathVariable String id, @Valid @RequestBody OrganizationDTO organizationDTO) {
         return organizationService.updateOrganizationFromDTO(id, organizationDTO);
     }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{id}")
+    public void deleteOrganization(@PathVariable String id) {
+        organizationService.deleteOrganizationById(id);
+    }
 }

--- a/backend/src/main/java/de/neuefische/backend/service/OrganizationService.java
+++ b/backend/src/main/java/de/neuefische/backend/service/OrganizationService.java
@@ -44,5 +44,13 @@ public class OrganizationService {
             return organizationRepo.save(updatedOrganization);
         } else throw new OrganizationNotFoundException(id);
     }
+
+    public void deleteOrganizationById(String id) {
+        if (!organizationRepo.existsById(id)) {
+            throw new OrganizationNotFoundException(id);
+        } else {
+            organizationRepo.deleteById(id);
+        }
+    }
 }
 

--- a/backend/src/test/java/de/neuefische/backend/controller/OrganizationControllerIntegrationTest.java
+++ b/backend/src/test/java/de/neuefische/backend/controller/OrganizationControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package de.neuefische.backend.controller;
 
 import de.neuefische.backend.model.Organization;
 import de.neuefische.backend.repository.OrganizationRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -167,5 +168,19 @@ class OrganizationControllerIntegrationTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message")
                         .value("Weiterbildungsanbieter mit id: 999 nicht gefunden"));
+    }
+
+    @Test
+    void deleteOrganization_whenExists_shouldReturnNoContent() throws Exception {
+        organizationRepository.save(testOrganization);
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/organizations/1"))
+                .andExpect(status().isNoContent());
+        Assertions.assertFalse(organizationRepository.existsById(testOrganization.id()));
+    }
+
+    @Test
+    void deleteOrganization_shouldReturn404_ifOrganizationNotExists() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/organizations/2"))
+                .andExpect(status().isNotFound());
     }
 }

--- a/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/service/OrganizationServiceTest.java
@@ -13,8 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.bson.assertions.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class OrganizationServiceTest {
@@ -114,4 +113,22 @@ class OrganizationServiceTest {
                 organizationService.updateOrganizationFromDTO(id, organizationDTO));
         verify(mockedOrganisationRepo).existsById(id);
     }
+
+    @Test
+    void deleteById_shouldThrowException_whenOrganizationNotExist() {
+        when(mockedOrganisationRepo.existsById("999")).thenReturn(false);
+        assertThrows(OrganizationNotFoundException.class, () -> organizationService.deleteOrganizationById("999"));
+        verify(mockedOrganisationRepo).existsById("999");
+    }
+
+    @Test
+    void deleteById_shouldDeleteOrganization_whenExists() {
+        when(mockedOrganisationRepo.existsById("1")).thenReturn(true);
+        organizationService.deleteOrganizationById("1");
+        verify(mockedOrganisationRepo).deleteById("1");
+        when(mockedOrganisationRepo.existsById("1")).thenReturn(false);
+        assertFalse(mockedOrganisationRepo.existsById("1"));
+
+    }
+
 }

--- a/frontend/src/components/OrganizationDetails.tsx
+++ b/frontend/src/components/OrganizationDetails.tsx
@@ -9,6 +9,7 @@ function OrganizationDetails() {
     const [organization, setOrganization] = useState<Organization | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [deleteSuccess, setDeleteSuccess] = useState(false);
 
     useEffect(() => {
 
@@ -32,6 +33,24 @@ function OrganizationDetails() {
 
     if (error) return <p>Error loading organization: {error}</p>;
 
+    function deleteOrganization() {
+        const userConfirmed = window.confirm("Sind Sie sicher, dass Sie diesen Anbieter löschen möchten?");
+        if (!userConfirmed) {
+            return;
+        }
+        axios.delete(`/api/organizations/${id}`)
+            .then(() => {
+                setDeleteSuccess(true); // Setze Erfolg auf true
+                setTimeout(() => {
+                    setDeleteSuccess(false);
+                    navigate('/');
+                    window.location.reload();
+                }, 3000);
+            })
+            .catch((err) => {
+                setError((err as Error).message || 'An error occurred while deleting the organization');
+            });
+    }
 
     return (
         <div>
@@ -51,6 +70,10 @@ function OrganizationDetails() {
             <button onClick={() => navigate(`/edit-organization/${id}`, {state: {organization}})}>
                 Bearbeiten
             </button>
+            <button onClick={deleteOrganization} className="delete-button">Löschen</button>
+            {deleteSuccess && (
+                <p className="success-message">Der Anbieter wurde gelöscht! Weiterleitung auf die Startseite...</p>
+            )}
         </div>
     );
 }

--- a/frontend/src/styles/OrganizationCard.css
+++ b/frontend/src/styles/OrganizationCard.css
@@ -24,3 +24,22 @@
     font-size: 0.9rem;
     color: #666;
 }
+
+.success-message {
+    color: green;
+    font-weight: bold;
+    margin-top: 10px;
+    font-size: 16px;
+}
+
+.delete-button {
+    background-color: #ff4d4f;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    padding: 10px 20px;
+    font-size: 16px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}


### PR DESCRIPTION
Backend:
Added DELETE endpoint "/api/organizations/{id}"
Implemented logic to throw OrganizationNotFoundException

Frontend:
Added delete button in OrganizationDetails page.
Integrated confirmation for deletion with success message.
Redirected user to the home page after successful deletion.

Tests:
Unit tests for delete functionality in OrganizationService.
Integration tests for the DELETE endpoint.