### PR TITLE
Refactor Api service

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -61,6 +61,18 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.16</version>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.5.12</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>app</finalName>

--- a/backend/src/main/java/de/neuefische/backend/api/dto/ApiResponseOrganization.java
+++ b/backend/src/main/java/de/neuefische/backend/api/dto/ApiResponseOrganization.java
@@ -15,14 +15,16 @@ public record ApiResponseOrganization(
 ) {
         @Override
         public boolean equals(Object o) {
-                if (this == o) return true;
-                if (o == null || getClass() != o.getClass()) return false;
+                if (this == o)
+                        return true;
+                if (o == null || getClass() != o.getClass())
+                        return false;
                 ApiResponseOrganization that = (ApiResponseOrganization) o;
-                return Objects.equals(name, that.name);
+                return Objects.equals(id, that.id);
         }
 
         @Override
         public int hashCode() {
-                return Objects.hashCode(name);
+                return Objects.hashCode(id);
         }
 }

--- a/backend/src/main/java/de/neuefische/backend/api/service/ArbeitsagenturApiService.java
+++ b/backend/src/main/java/de/neuefische/backend/api/service/ArbeitsagenturApiService.java
@@ -7,6 +7,8 @@ import de.neuefische.backend.api.dto.ApiResponseOrganization;
 import de.neuefische.backend.api.exception.ApiResponseException;
 import de.neuefische.backend.model.Organization;
 import de.neuefische.backend.service.IdService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
@@ -19,6 +21,7 @@ public class ArbeitsagenturApiService {
 
     private final RestClient restClient;
     private final IdService idService;
+    private static final Logger logger = LoggerFactory.getLogger(ArbeitsagenturApiService.class);
 
     public ArbeitsagenturApiService(RestClient.Builder builder, IdService idService) {
         this.restClient =
@@ -36,7 +39,7 @@ public class ArbeitsagenturApiService {
                         restClient.get().uri(urlPage).header("X-API-Key", "infosysbub-wbsuche").retrieve().body(ApiResponse.class);
 
                 if (response == null || response.responseContent() == null || response.responseContent().details() == null) {
-                    System.out.println("Fehler: responseContent ist null für die Seite " + urlPage);
+                    logger.error("Fehler: responseContent ist null für die Seite {}", urlPage);
                     break;
                 }
 

--- a/backend/src/main/java/de/neuefische/backend/api/service/ArbeitsagenturApiService.java
+++ b/backend/src/main/java/de/neuefische/backend/api/service/ArbeitsagenturApiService.java
@@ -45,7 +45,7 @@ public class ArbeitsagenturApiService {
                 List<ApiResponseOrganization> apiResponseOrganizations =
                         details.stream().map(ApiResponseDetails::courseOffer).map(ApiResponseCourseOffer::apiResponseOrganization).distinct().toList();
 
-                apiOrganizations.addAll(getOrganizations(apiResponseOrganizations));
+                apiOrganizations.addAll(convertApiOrganizationsToOrganizations(apiResponseOrganizations));
                 urlPage = getNextPageUrl(response);
             } catch (Exception e) {
                 throw new ApiResponseException();
@@ -55,7 +55,7 @@ public class ArbeitsagenturApiService {
         return apiOrganizations.stream().distinct().toList();
     }
 
-    public List<Organization> getOrganizations(List<ApiResponseOrganization> apiResponseOrganizations) {
+    public List<Organization> convertApiOrganizationsToOrganizations(List<ApiResponseOrganization> apiResponseOrganizations) {
 
         return apiResponseOrganizations.stream().map(a -> new Organization(idService.generateRandomId(), a.name(),
                 a.homepage(), a.email(),

--- a/backend/src/main/java/de/neuefische/backend/api/service/ArbeitsagenturApiService.java
+++ b/backend/src/main/java/de/neuefische/backend/api/service/ArbeitsagenturApiService.java
@@ -61,8 +61,7 @@ public class ArbeitsagenturApiService {
     public List<Organization> convertApiOrganizationsToOrganizations(List<ApiResponseOrganization> apiResponseOrganizations) {
 
         return apiResponseOrganizations.stream().map(a -> new Organization(idService.generateRandomId(), a.name(),
-                a.homepage(), a.email(),
-                a.address().addressDetails().postalCode() + " " + a.address().addressDetails().city() + ", " + a.address().streetAndHomeNumber())).toList();
+                a.homepage(), a.email(), a.address().streetAndHomeNumber() + ", " + a.address().addressDetails().postalCode() + " " + a.address().addressDetails().city())).toList();
     }
 
     public String getNextPageUrl(ApiResponse apiResponse) {

--- a/backend/src/main/java/de/neuefische/backend/api/service/ArbeitsagenturApiService.java
+++ b/backend/src/main/java/de/neuefische/backend/api/service/ArbeitsagenturApiService.java
@@ -20,10 +20,10 @@ public class ArbeitsagenturApiService {
     private final RestClient restClient;
     private final IdService idService;
 
-    public ArbeitsagenturApiService(RestClient.Builder builder) {
+    public ArbeitsagenturApiService(RestClient.Builder builder, IdService idService) {
         this.restClient =
                 builder.baseUrl("https://rest.arbeitsagentur.de/infosysbub/wbsuche/pc/v2/bildungsangebot").build();
-        this.idService = new IdService();
+        this.idService = idService;
     }
 
     public List<Organization> loadAllOrganizations() {

--- a/backend/src/test/java/de/neuefische/backend/api/dto/ApiResponseOrganizationTest.java
+++ b/backend/src/test/java/de/neuefische/backend/api/dto/ApiResponseOrganizationTest.java
@@ -8,21 +8,22 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 class ApiResponseOrganizationTest {
 
     @Test
-    void equals_shouldReturnTrueForEqualNames() {
+    void equals_shouldReturnTrueForEqualIds() {
         long id = 123;
-        ApiResponseOrganization apiResponseOrganization1 = new ApiResponseOrganization(id, "testname", "testhomepage"
+        ApiResponseOrganization apiResponseOrganization1 = new ApiResponseOrganization(id, "testname1", "testhomepage"
                 , "testmail", new ApiResponseAddress("testStreet", new ApiResponseAddressDetails("11", "Berlin")));
-        ApiResponseOrganization apiResponseOrganization2 = new ApiResponseOrganization(id, "testname", "testhomepage2"
+        ApiResponseOrganization apiResponseOrganization2 = new ApiResponseOrganization(id, "testname2", "testhomepage2"
                 , "testmail2", new ApiResponseAddress("testStreet2", new ApiResponseAddressDetails("112", "Hamburg")));
         assertEquals(apiResponseOrganization1, apiResponseOrganization2);
     }
 
     @Test
     void equals_shouldReturnFalseForNotEqualNames() {
-        long id = 123;
-        ApiResponseOrganization apiResponseOrganization1 = new ApiResponseOrganization(id, "testname", "testhomepage"
+        long id1 = 123;
+        long id2 = 456;
+        ApiResponseOrganization apiResponseOrganization1 = new ApiResponseOrganization(id1, "testname1", "testhomepage"
                 , "testmail", new ApiResponseAddress("testStreet", new ApiResponseAddressDetails("11", "Berlin")));
-        ApiResponseOrganization apiResponseOrganization2 = new ApiResponseOrganization(id, "testname2", "testhomepage"
+        ApiResponseOrganization apiResponseOrganization2 = new ApiResponseOrganization(id2, "testname2", "testhomepage"
                 , "testmail", new ApiResponseAddress("testStreet", new ApiResponseAddressDetails("11", "Berlin")));
         assertNotEquals(apiResponseOrganization1, apiResponseOrganization2);
     }

--- a/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceIntegrationTest.java
+++ b/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package de.neuefische.backend.api.service;
 
 import de.neuefische.backend.api.exception.ApiResponseException;
 import de.neuefische.backend.model.Organization;
+import de.neuefische.backend.service.IdService;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
@@ -17,9 +18,10 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 class ArbeitsagenturApiServiceIntegrationTest {
 
+    private final IdService idService = new IdService();
     private final RestClient.Builder builder = RestClient.builder();
     private final MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
-    private final ArbeitsagenturApiService apiService = new ArbeitsagenturApiService(builder);
+    private final ArbeitsagenturApiService apiService = new ArbeitsagenturApiService(builder, idService);
 
     @Test
     void loadAllOrganizations_shouldReturnOrganizationsFromApi() {

--- a/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceIntegrationTest.java
+++ b/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceIntegrationTest.java
@@ -71,8 +71,7 @@ class ArbeitsagenturApiServiceIntegrationTest {
         server.expect(requestTo("https://rest.arbeitsagentur.de/infosysbub/wbsuche/pc/v2/bildungsangebot?page=0&size" +
                                 "=20")).andExpect(method(HttpMethod.GET)).andRespond(withServerError());
 
-        org.junit.jupiter.api.Assertions.assertThrows(ApiResponseException.class,
-                () -> apiService.loadAllOrganizations());
+        org.junit.jupiter.api.Assertions.assertThrows(ApiResponseException.class, apiService::loadAllOrganizations);
 
         server.verify();
     }

--- a/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceTest.java
@@ -20,15 +20,15 @@ class ArbeitsagenturApiServiceTest {
     ArbeitsagenturApiService apiService = new ArbeitsagenturApiService(RestClient.builder(), idService);
 
     @Test
-    void getOrganizations_returnsEmptyList_whenNoApiResponseOrganization() {
+    void convertApiOrganizationsToOrganizations_returnsEmptyList_whenNoApiResponseOrganization() {
         List<ApiResponseOrganization> apiResponseOrganizations = List.of();
 
-        List<Organization> organizations = apiService.getOrganizations(apiResponseOrganizations);
+        List<Organization> organizations = apiService.convertApiOrganizationsToOrganizations(apiResponseOrganizations);
         assertTrue(organizations.isEmpty());
     }
 
     @Test
-    void getOrganizations_returnsList_whenApiResponseOrganizationsAreProvided() {
+    void convertApiOrganizationsToOrganizations_returnsList_whenApiResponseOrganizationsAreProvided() {
         ApiResponseAddressDetails addressDetails = new ApiResponseAddressDetails("99084", "Erfurt");
         ApiResponseAddress address = new ApiResponseAddress("Juri-Gagarin-Ring 152", addressDetails);
 
@@ -38,7 +38,7 @@ class ArbeitsagenturApiServiceTest {
 
         List<ApiResponseOrganization> apiResponseOrganizations = List.of(apiResponseOrganization);
 
-        List<Organization> organizations = apiService.getOrganizations(apiResponseOrganizations);
+        List<Organization> organizations = apiService.convertApiOrganizationsToOrganizations(apiResponseOrganizations);
 
         assertNotNull(organizations);
         assertEquals(1, organizations.size());

--- a/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceTest.java
@@ -43,7 +43,7 @@ class ArbeitsagenturApiServiceTest {
         assertNotNull(organizations);
         assertEquals(1, organizations.size());
         assertEquals("Test Organization", organizations.getFirst().name());
-        assertEquals("99084 Erfurt, Juri-Gagarin-Ring 152", organizations.getFirst().address());
+        assertEquals("Juri-Gagarin-Ring 152, 99084 Erfurt", organizations.getFirst().address());
 
     }
 

--- a/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceTest.java
@@ -2,6 +2,7 @@ package de.neuefische.backend.api.service;
 
 import de.neuefische.backend.api.dto.*;
 import de.neuefische.backend.model.Organization;
+import de.neuefische.backend.service.IdService;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestClient;
 
@@ -15,7 +16,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class ArbeitsagenturApiServiceTest {
-    ArbeitsagenturApiService apiService = new ArbeitsagenturApiService(RestClient.builder());
+    IdService idService = new IdService();
+    ArbeitsagenturApiService apiService = new ArbeitsagenturApiService(RestClient.builder(), idService);
 
     @Test
     void getOrganizations_returnsEmptyList_whenNoApiResponseOrganization() {


### PR DESCRIPTION
Backend:
-Replaced System.out.println statements with Logger
-Updated the address format handling in convertApiOrganizationsToOrganizations 
-Renamed the method getOrganizations to convertApiOrganizationsToOrganizations for better clarity
-Corrected dependency injection of IdService and updated related
-Updated equality checks for ApiResponseOrganization to be based on the id field

Tests:
Updated unit tests to reflect changes