### PR TITLE
Save api organizations

### DIFF
--- a/backend/src/main/java/de/neuefische/backend/controller/OrganizationController.java
+++ b/backend/src/main/java/de/neuefische/backend/controller/OrganizationController.java
@@ -43,4 +43,9 @@ public class OrganizationController {
     public void deleteOrganization(@PathVariable String id) {
         organizationService.deleteOrganizationById(id);
     }
+
+    @PutMapping("/refresh")
+    public List<Organization> refreshOrganizationsFromApi() {
+        return organizationService.refreshOrganizationsFromApi();
+    }
 }

--- a/backend/src/main/java/de/neuefische/backend/repository/OrganizationRepository.java
+++ b/backend/src/main/java/de/neuefische/backend/repository/OrganizationRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrganizationRepository extends MongoRepository<Organization, String> {
+    boolean existsByName(String name);
 }

--- a/backend/src/main/java/de/neuefische/backend/service/OrganizationService.java
+++ b/backend/src/main/java/de/neuefische/backend/service/OrganizationService.java
@@ -21,34 +21,39 @@ public class OrganizationService {
     private final ArbeitsagenturApiService apiService;
 
     public List<Organization> getAllOrganizations() {
-        List<Organization> allOrganizations = new ArrayList<>();
-        allOrganizations.addAll(organizationRepo.findAll());
-        allOrganizations.addAll(apiService.loadAllOrganizations());
-        return allOrganizations;
+        List<Organization> apiOrganizations = apiService.loadAllOrganizations();
+        saveApiOrganizations(apiOrganizations);
+        return new ArrayList<>(organizationRepo.findAll());
+    }
+
+    public void saveApiOrganizations(List<Organization> apiOrganizations) {
+        for (Organization apiOrganization : apiOrganizations) {
+            if (!organizationRepo.existsByName(apiOrganization.name())) {
+                organizationRepo.save(apiOrganization);
+            }
+        }
     }
 
     public Organization saveOrganizationFromDTO(OrganizationDTO organizationDTO) {
-        Organization organization = new Organization(
-                idService.generateRandomId(),
-                organizationDTO.name(), organizationDTO.homepage(),
-                organizationDTO.email(), organizationDTO.address());
+        Organization organization = new Organization(idService.generateRandomId(), organizationDTO.name(),
+                organizationDTO.homepage(), organizationDTO.email(), organizationDTO.address());
         return organizationRepo.save(organization);
     }
 
     public OrganizationDTO getOrganizationDTObyId(String id) {
-        Organization organization = organizationRepo.findById(id)
-                .orElseThrow(() -> new OrganizationNotFoundException(id));
+        Organization organization =
+                organizationRepo.findById(id).orElseThrow(() -> new OrganizationNotFoundException(id));
         return new OrganizationDTO(organization.name(), organization.homepage(), organization.email(),
                 organization.address());
     }
 
     public Organization updateOrganizationFromDTO(String id, @Valid OrganizationDTO organizationDTO) {
         if (organizationRepo.existsById(id)) {
-            Organization updatedOrganization = new Organization(id, organizationDTO.name(), organizationDTO.homepage(),
-                    organizationDTO.email(),
-                    organizationDTO.address());
+            Organization updatedOrganization = new Organization(id, organizationDTO.name(),
+                    organizationDTO.homepage(), organizationDTO.email(), organizationDTO.address());
             return organizationRepo.save(updatedOrganization);
-        } else throw new OrganizationNotFoundException(id);
+        } else
+            throw new OrganizationNotFoundException(id);
     }
 
     public void deleteOrganizationById(String id) {

--- a/backend/src/test/java/de/neuefische/backend/controller/OrganizationControllerIntegrationTest.java
+++ b/backend/src/test/java/de/neuefische/backend/controller/OrganizationControllerIntegrationTest.java
@@ -14,10 +14,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
@@ -39,108 +39,70 @@ class OrganizationControllerIntegrationTest {
     @BeforeEach
     void setUp() {
         organizationRepository.deleteAll();
-        testOrganization = new Organization("1", "testname", "testhomepage",
-                "testemail", "testaddress");
+        testOrganization = new Organization("1", "testname", "testhomepage", "testemail", "testaddress");
     }
 
     @Test
     void getAllOrganizations_shouldReturnListOfOrganizations() throws Exception {
-        List<Organization> apiOrganizations = List.of(new Organization("2", "apiOrganization", "apiHomepage",
-                "apiEmail", "apiAddress"));
         organizationRepository.save(testOrganization);
 
-        when(mockedApiService.loadAllOrganizations()).thenReturn(apiOrganizations);
-
-
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations"))
-                .andExpect(status().isOk()).andExpect(content().json("""
-                            [
-                                {
-                                    "id": "1",
-                                    "name": "testname",
-                                    "homepage": "testhomepage",
-                                    "email": "testemail",
-                                    "address": "testaddress"
-                                },
-                                {
-                                    "id": "2",
-                                    "name": "apiOrganization",
-                                    "homepage": "apiHomepage",
-                                    "email": "apiEmail",
-                                    "address": "apiAddress"
-                                }
-                            ]
-                        """));
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations")).andExpect(status().isOk()).andExpect(content().json("""
+                    [
+                        {
+                            "id": "1",
+                            "name": "testname",
+                            "homepage": "testhomepage",
+                            "email": "testemail",
+                            "address": "testaddress"
+                        }
+                    ]
+                """));
 
     }
 
 
     @Test
-    void getAllOrganizations_shouldReturnEmptyListWhenNoOrganisations() throws Exception {
+    void getAllOrganizations_shouldReturnEmptyListWhenNoOrganisationsInRepo() throws Exception {
         organizationRepository.deleteAll();
-        List<Organization> emptyApiResponse = Collections.emptyList();
-        when(mockedApiService.loadAllOrganizations()).thenReturn(emptyApiResponse);
-
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations"))
-                .andExpect(status().isOk()).andExpect(content().json("[]"));
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations")).andExpect(status().isOk()).andExpect(content().json("[]"));
     }
 
 
     @Test
     void addOrganization_shouldSaveOrganizationWithId() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/organizations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                "name": "testorganization",
-                                "homepage": "testhomepage"
-                                }
-                                """))
-                .andExpect(status().isCreated())
-                .andExpect(content().json(
-                        """
-                                {
-                                "name": "testorganization",
-                                "homepage": "testhomepage"
-                                }
-                                """
-                )).andExpect(jsonPath("$.id").isNotEmpty());
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/organizations").contentType(MediaType.APPLICATION_JSON).content("""
+                {
+                "name": "testorganization",
+                "homepage": "testhomepage"
+                }
+                """)).andExpect(status().isCreated()).andExpect(content().json("""
+                {
+                "name": "testorganization",
+                "homepage": "testhomepage"
+                }
+                """)).andExpect(jsonPath("$.id").isNotEmpty());
 
     }
 
     @Test
     void addOrganization_returnBadRequest_whenOrganizationNameMissing() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/organizations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                "homepage": "testhomepage"
-                                }
-                                """))
-                .andExpect(status().isBadRequest());
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/organizations").contentType(MediaType.APPLICATION_JSON).content("""
+                {
+                "homepage": "testhomepage"
+                }
+                """)).andExpect(status().isBadRequest());
     }
 
     @Test
     void getOrganizationById_shouldReturnOrganizationDTO() throws Exception {
         organizationRepository.save(testOrganization);
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations/{id}", "1")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.name").value("testname"))
-                .andExpect(jsonPath("$.homepage").value("testhomepage"))
-                .andExpect(jsonPath("$.email").value("testemail"))
-                .andExpect(jsonPath("$.address").value("testaddress"));
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations/{id}", "1").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON)).andExpect(jsonPath("$.name").value("testname")).andExpect(jsonPath("$.homepage").value("testhomepage")).andExpect(jsonPath("$.email").value("testemail")).andExpect(jsonPath("$.address").value("testaddress"));
     }
 
     @Test
     void getOrganizationById_shouldReturnNotFound_whenOrganizationDoesNotExist() throws Exception {
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations/{id}", "nonexistentId")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message")
-                        .value("Weiterbildungsanbieter mit id: nonexistentId nicht gefunden"));
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/organizations/{id}", "nonexistentId").accept(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound()).andExpect(jsonPath("$.message").value("Weiterbildungsanbieter mit id: nonexistentId nicht gefunden"));
     }
 
     @Test
@@ -164,13 +126,7 @@ class OrganizationControllerIntegrationTest {
                 }
                 """;
 
-        mockMvc.perform(MockMvcRequestBuilders.put("/api/organizations/{id}", id)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponseBody))
-                .andExpect(jsonPath("$.id").value(id));
+        mockMvc.perform(put("/api/organizations/{id}", id).contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(requestBody)).andExpect(status().isOk()).andExpect(content().json(expectedResponseBody)).andExpect(jsonPath("$.id").value(id));
     }
 
     @Test
@@ -186,26 +142,43 @@ class OrganizationControllerIntegrationTest {
                 }
                 """;
 
-        mockMvc.perform(MockMvcRequestBuilders.put("/api/organizations/{id}", nonExistingId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message")
-                        .value("Weiterbildungsanbieter mit id: 999 nicht gefunden"));
+        mockMvc.perform(put("/api/organizations/{id}", nonExistingId).contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(requestBody)).andExpect(status().isNotFound()).andExpect(jsonPath("$.message").value("Weiterbildungsanbieter mit id: 999 nicht gefunden"));
     }
 
     @Test
     void deleteOrganization_whenExists_shouldReturnNoContent() throws Exception {
         organizationRepository.save(testOrganization);
-        mockMvc.perform(MockMvcRequestBuilders.delete("/api/organizations/1"))
-                .andExpect(status().isNoContent());
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/organizations/1")).andExpect(status().isNoContent());
         Assertions.assertFalse(organizationRepository.existsById(testOrganization.id()));
     }
 
     @Test
     void deleteOrganization_shouldReturn404_ifOrganizationNotExists() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.delete("/api/organizations/2"))
-                .andExpect(status().isNotFound());
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/organizations/2")).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void refreshOrganizations_shouldReturnListOfOrganizations() throws Exception {
+        when(mockedApiService.loadAllOrganizations()).thenReturn(List.of(testOrganization));
+
+        mockMvc.perform(put("/api/organizations/refresh")).andExpect(status().isOk()).andExpect(content().json("""
+                    [
+                        {
+                            "id": "1",
+                            "name": "testname",
+                            "homepage": "testhomepage",
+                            "email": "testemail",
+                            "address": "testaddress"
+                        }
+                    ]
+                """));
+
+    }
+
+    @Test
+    void refreshOrganizations_shouldReturnEmptyList_whenNoNewOrganizations() throws Exception {
+        organizationRepository.save(testOrganization);
+        when(mockedApiService.loadAllOrganizations()).thenReturn(List.of(testOrganization));
+        mockMvc.perform(put("/api/organizations/refresh")).andExpect(status().isOk()).andExpect(content().json("[]"));
     }
 }


### PR DESCRIPTION
Backend:
Added a new endpoint to save organizations from an external API.
Enhanced OrganizationService with functionality to save API organizations and added a logger for better tracking.
Extended OrganizationRepository with the existsByName method to validate if an organization already exists.

Tests:
Added unit and integration tests to cover the new endpoint, service functionality, and repository changes.