### PR TITLE
Reorder address components

### DIFF
--- a/backend/src/main/java/de/neuefische/backend/api/service/ArbeitsagenturApiService.java
+++ b/backend/src/main/java/de/neuefische/backend/api/service/ArbeitsagenturApiService.java
@@ -62,7 +62,8 @@ public class ArbeitsagenturApiService {
 
         return apiResponseOrganizations.stream().map(a -> new Organization(idService.generateRandomId(), a.name(),
                 a.homepage(), a.email(),
-                a.address().addressDetails().postalCode() + " " + a.address().addressDetails().city() + ", " + a.address().streetAndHomeNumber())).toList();
+
+                a.address().streetAndHomeNumber() + ", " + a.address().addressDetails().postalCode() + " " + a.address().addressDetails().city())).toList();
     }
 
     public String getNextPageUrl(ApiResponse apiResponse) {

--- a/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/api/service/ArbeitsagenturApiServiceTest.java
@@ -43,7 +43,7 @@ class ArbeitsagenturApiServiceTest {
         assertNotNull(organizations);
         assertEquals(1, organizations.size());
         assertEquals("Test Organization", organizations.getFirst().name());
-        assertEquals("99084 Erfurt, Juri-Gagarin-Ring 152", organizations.getFirst().address());
+        assertEquals("Juri-Gagarin-Ring 152, 99084 Erfurt", organizations.getFirst().address());
 
     }
 


### PR DESCRIPTION
Backend:
Reorganized the order of address components in the convertApiOrganizationsToOrganizations method to improve readability on the organization detail page.

Tests:
Updated unit tests to reflect the new address component order.