### PR TITLE
Refactor organization service

### DIFF
--- a/backend/src/main/java/de/neuefische/backend/organization/OrganizationController.java
+++ b/backend/src/main/java/de/neuefische/backend/organization/OrganizationController.java
@@ -32,8 +32,8 @@ public class OrganizationController {
     }
 
     @GetMapping("/{id}")
-    public OrganizationDTO getOrganizationById(@PathVariable String id) {
-        return organizationService.getOrganizationDTObyId(id);
+    public Organization getOrganizationById(@PathVariable String id) {
+        return organizationService.getOrganizationById(id);
     }
 
     @PutMapping("/{id}")

--- a/backend/src/main/java/de/neuefische/backend/organization/OrganizationRepository.java
+++ b/backend/src/main/java/de/neuefische/backend/organization/OrganizationRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 public interface OrganizationRepository extends MongoRepository<Organization, String> {
 
     boolean existsByName(String name);
+    boolean existsByApiId(Long apiId);
 }

--- a/backend/src/main/java/de/neuefische/backend/organization/OrganizationService.java
+++ b/backend/src/main/java/de/neuefische/backend/organization/OrganizationService.java
@@ -35,19 +35,17 @@ public class OrganizationService {
 
 
     public Page<Organization> getAllOrganizations(int page, int size, String search) {
-        Pageable pageable;
-        pageable = PageRequest.of(page, size);
-        Query query = new Query().with(Sort.by(new Sort.Order(Sort.Direction.ASC, "name"))).with(pageable);
-
-        if (search != null && !search.isEmpty()) {
-
+        Pageable pageable = PageRequest.of(page, size);
+        Query query = new Query().with(Sort.by(new Sort.Order(Sort.Direction.ASC, "name")))
+                                 .with(pageable);
+        if (!search.isEmpty()) {
             String sanitizedSearch = Pattern.quote(search);
-            query.addCriteria(Criteria.where("name").regex(sanitizedSearch, "i"));
+            query.addCriteria(Criteria.where("name")
+                                      .regex(sanitizedSearch, "i"));
         }
-
-        query.collation(Collation.of("en").strength(Collation.ComparisonLevel.secondary()));
+        query.collation(Collation.of("en")
+                                 .strength(Collation.ComparisonLevel.secondary()));
         List<Organization> sortedOrganizations = mongoTemplate.find(query, Organization.class);
-
         return PageableExecutionUtils.getPage(sortedOrganizations, pageable, organizationRepo::count);
     }
 
@@ -70,23 +68,23 @@ public class OrganizationService {
 
     public Organization saveOrganizationFromDTO(OrganizationDTO organizationDTO) {
         Organization organization = new Organization(idService.generateRandomId(), null, organizationDTO.name(),
-                organizationDTO.homepage(), organizationDTO.email(), organizationDTO.address(), new ArrayList<>(),
-                0.0,new ArrayList<>());
+                organizationDTO.homepage(), organizationDTO.email(), organizationDTO.address(), new ArrayList<>(), 0.0,
+                new ArrayList<>());
         return organizationRepo.save(organization);
     }
 
     public OrganizationDTO getOrganizationDTObyId(String id) {
-        Organization organization =
-                organizationRepo.findById(id).orElseThrow(() -> new OrganizationNotFoundException(id));
+        Organization organization = organizationRepo.findById(id)
+                                                    .orElseThrow(() -> new OrganizationNotFoundException(id));
         return new OrganizationDTO(organization.name(), organization.homepage(), organization.email(),
                 organization.address(), organization.reviews(), organization.averageRating(), organization.courses());
     }
 
     public Organization updateOrganizationFromDTO(String id, OrganizationDTO organizationDTO) {
         if (organizationRepo.existsById(id)) {
-            Organization updatedOrganization = new Organization(id,null, organizationDTO.name(),
+            Organization updatedOrganization = new Organization(id, null, organizationDTO.name(),
                     organizationDTO.homepage(), organizationDTO.email(), organizationDTO.address(),
-                    organizationDTO.reviews(), organizationDTO.averageRating(),new ArrayList<>());
+                    organizationDTO.reviews(), organizationDTO.averageRating(), new ArrayList<>());
             return organizationRepo.save(updatedOrganization);
         } else
             throw new OrganizationNotFoundException(id);
@@ -103,13 +101,18 @@ public class OrganizationService {
     public Organization addReviewToOrganization(String organizationId, ReviewDTO reviewDTO) {
         Review review = new Review(idService.generateRandomId(), reviewDTO.author(), reviewDTO.comment(),
                 reviewDTO.starNumber());
-        Organization organization =
-                organizationRepo.findById(organizationId).orElseThrow(() -> new OrganizationNotFoundException(organizationId));
+        Organization organization = organizationRepo.findById(organizationId)
+                                                    .orElseThrow(
+                                                            () -> new OrganizationNotFoundException(organizationId));
         List<Review> reviews = new ArrayList<>(organization.reviews());
         reviews.add(review);
-        double averageRating = reviews.stream().mapToInt(Review::starNumber).average().orElse(0.0);
+        double averageRating = reviews.stream()
+                                      .mapToInt(Review::starNumber)
+                                      .average()
+                                      .orElse(0.0);
 
-        Organization actualisedOrganization = organization.withReviews(reviews).withAverageRating(averageRating);
+        Organization actualisedOrganization = organization.withReviews(reviews)
+                                                          .withAverageRating(averageRating);
         organizationRepo.save(actualisedOrganization);
         return actualisedOrganization;
     }

--- a/backend/src/main/java/de/neuefische/backend/organization/OrganizationService.java
+++ b/backend/src/main/java/de/neuefische/backend/organization/OrganizationService.java
@@ -53,7 +53,7 @@ public class OrganizationService {
         List<Organization> apiOrganizations = apiService.loadAllOrganizations();
         List<Organization> savedApiOrganizations = new ArrayList<>();
         for (Organization apiOrganization : apiOrganizations) {
-            if (!organizationRepo.existsByName(apiOrganization.name())) {
+            if (!organizationRepo.existsByApiId(apiOrganization.apiId())) {
                 organizationRepo.save(apiOrganization);
                 savedApiOrganizations.add(apiOrganization);
             }

--- a/backend/src/main/java/de/neuefische/backend/organization/OrganizationService.java
+++ b/backend/src/main/java/de/neuefische/backend/organization/OrganizationService.java
@@ -80,11 +80,10 @@ public class OrganizationService {
     }
 
     public Organization updateOrganizationFromDTO(String id, OrganizationDTO organizationDTO) {
-        if (organizationRepo.existsById(id)) {
-            Organization updatedOrganization = new Organization(id, organizationDTO);
-            return organizationRepo.save(updatedOrganization);
-        } else
+        if (!organizationRepo.existsById(id)) {
             throw new OrganizationNotFoundException(id);
+        }
+        return organizationRepo.save(new Organization(id, organizationDTO));
     }
 
     public void deleteOrganizationById(String id) {

--- a/backend/src/main/java/de/neuefische/backend/organization/OrganizationService.java
+++ b/backend/src/main/java/de/neuefische/backend/organization/OrganizationService.java
@@ -72,11 +72,8 @@ public class OrganizationService {
         return organizationRepo.save(organization);
     }
 
-    public OrganizationDTO getOrganizationDTObyId(String id) {
-        Organization organization = organizationRepo.findById(id)
-                                                    .orElseThrow(() -> new OrganizationNotFoundException(id));
-        return new OrganizationDTO(organization.name(), organization.homepage(), organization.email(),
-                organization.address(), organization.reviews(), organization.averageRating(), organization.courses());
+    public Organization getOrganizationById(String id) {
+        return organizationRepo.findById(id).orElseThrow(() -> new OrganizationNotFoundException(id));
     }
 
     public Organization updateOrganizationFromDTO(String id, OrganizationDTO organizationDTO) {

--- a/backend/src/main/java/de/neuefische/backend/organization/OrganizationService.java
+++ b/backend/src/main/java/de/neuefische/backend/organization/OrganizationService.java
@@ -67,9 +67,8 @@ public class OrganizationService {
     }
 
     public Organization saveOrganizationFromDTO(OrganizationDTO organizationDTO) {
-        Organization organization = new Organization(idService.generateRandomId(), null, organizationDTO.name(),
-                organizationDTO.homepage(), organizationDTO.email(), organizationDTO.address(), new ArrayList<>(), 0.0,
-                new ArrayList<>());
+        String id = idService.generateRandomId();
+        Organization organization = new Organization(id, organizationDTO);
         return organizationRepo.save(organization);
     }
 
@@ -82,9 +81,7 @@ public class OrganizationService {
 
     public Organization updateOrganizationFromDTO(String id, OrganizationDTO organizationDTO) {
         if (organizationRepo.existsById(id)) {
-            Organization updatedOrganization = new Organization(id, null, organizationDTO.name(),
-                    organizationDTO.homepage(), organizationDTO.email(), organizationDTO.address(),
-                    organizationDTO.reviews(), organizationDTO.averageRating(), new ArrayList<>());
+            Organization updatedOrganization = new Organization(id, organizationDTO);
             return organizationRepo.save(updatedOrganization);
         } else
             throw new OrganizationNotFoundException(id);

--- a/backend/src/main/java/de/neuefische/backend/organization/model/Organization.java
+++ b/backend/src/main/java/de/neuefische/backend/organization/model/Organization.java
@@ -4,20 +4,33 @@ package de.neuefische.backend.organization.model;
 import jakarta.validation.Valid;
 import lombok.With;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 @With
 public record Organization(String id,
-                           Long apiId,
-                           String name,
-                           String homepage,
-                           String email,
-                           String address,
-                           List<@Valid Review> reviews,
-                           double averageRating,
-                           List <Course> courses
-                          ) {
+        Long apiId,
+        String name,
+        String homepage,
+        String email,
+        String address,
+        List<@Valid Review> reviews,
+        double averageRating,
+        List<Course> courses) {
+
+    public Organization(String id, OrganizationDTO organizationDTO) {
+        this(id,
+                null,
+                organizationDTO.name(),
+                organizationDTO.homepage(),
+                organizationDTO.email(),
+                organizationDTO.address(),
+                organizationDTO.reviews() != null ? organizationDTO.reviews() : new ArrayList<>(),
+                organizationDTO.averageRating(),
+                organizationDTO.courses() != null ? organizationDTO.courses() : new ArrayList<>());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -32,4 +45,4 @@ public record Organization(String id,
     public int hashCode() {
         return Objects.hashCode(name);
     }
-}
+    }

--- a/backend/src/test/java/de/neuefische/backend/organization/OrganizationServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/organization/OrganizationServiceTest.java
@@ -82,25 +82,25 @@ class OrganizationServiceTest {
     void refreshOrganizationsFromApi_shouldSaveOrganizationFromApi_ifApiOrganizationNotExistInRepo() {
         List<Organization> expected = new ArrayList<>(List.of(testOrganization));
         when(mockedApiService.loadAllOrganizations()).thenReturn(expected);
-        when(mockedOrganisationRepo.existsByName(testOrganization.name())).thenReturn(false);
+        when(mockedOrganisationRepo.existsByApiId(testOrganization.apiId())).thenReturn(false);
         when(mockedOrganisationRepo.save(testOrganization)).thenReturn(testOrganization);
 
         List<Organization> actual = organizationService.refreshOrganizationsFromApi();
 
         verify(mockedOrganisationRepo).save(testOrganization);
-        verify(mockedOrganisationRepo).existsByName(testOrganization.name());
+        verify(mockedOrganisationRepo).existsByApiId(testOrganization.apiId());
         assertEquals(expected, actual);
     }
 
     @Test
-    void saveApiOrganizations_shouldNotSaveOrganizationIfItAlreadyExistsInRepo() {
+    void refreshOrganizationsFromApi_shouldNotSaveOrganizationIfItAlreadyExistsInRepo() {
         List<Organization> expected = new ArrayList<>(List.of(testOrganization));
         when(mockedApiService.loadAllOrganizations()).thenReturn(expected);
-        when(mockedOrganisationRepo.existsByName(testOrganization.name())).thenReturn(true);
+        when(mockedOrganisationRepo.existsByApiId(testOrganization.apiId())).thenReturn(true);
 
         List<Organization> actual = organizationService.refreshOrganizationsFromApi();
 
-        verify(mockedOrganisationRepo).existsByName(testOrganization.name());
+        verify(mockedOrganisationRepo).existsByApiId(testOrganization.apiId());
         verify(mockedOrganisationRepo, times(0)).save(testOrganization);
         Assertions.assertTrue(actual.isEmpty());
 
@@ -108,8 +108,8 @@ class OrganizationServiceTest {
 
     @Test
     void saveOrganizationFromDTO_shouldReturnOrganizationWithGeneratedId() {
-        OrganizationDTO organizationDTO = new OrganizationDTO("testname", "testhomepage", "testemail", "testaddress",
-                new ArrayList<>(), 0.0,new ArrayList<>());
+        OrganizationDTO organizationDTO = new OrganizationDTO("testname", "testhomepage",
+                "testemail", "testaddress", new ArrayList<>(), 0.0,new ArrayList<>());
         when(mockedOrganisationRepo.save(testOrganization)).thenReturn(testOrganization);
         when(mockedIdService.generateRandomId()).thenReturn("1");
         when(mockedOrganisationRepo.existsByName("testname2")).thenReturn(false);

--- a/backend/src/test/java/de/neuefische/backend/organization/OrganizationServiceTest.java
+++ b/backend/src/test/java/de/neuefische/backend/organization/OrganizationServiceTest.java
@@ -123,9 +123,9 @@ class OrganizationServiceTest {
     }
 
     @Test
-    void getOrganizationDTObyId_shouldReturnOrganizationDTO() {
+    void getOrganizationById_returnsCorrectOrganization() {
         when(mockedOrganisationRepo.findById("1")).thenReturn(Optional.of(testOrganization));
-        OrganizationDTO result = organizationService.getOrganizationDTObyId("1");
+        Organization result = organizationService.getOrganizationById("1");
         assertNotNull(result);
         verify(mockedOrganisationRepo).findById("1");
         assertEquals("testname", result.name());
@@ -138,7 +138,7 @@ class OrganizationServiceTest {
     void getOrganizationById_shouldThrowOrganizationNotFoundException() {
         when(mockedOrganisationRepo.findById("nonexistentId")).thenReturn(Optional.empty());
         Assertions.assertThrows(OrganizationNotFoundException.class,
-                () -> organizationService.getOrganizationDTObyId("nonexistentId"));
+                () -> organizationService.getOrganizationById("nonexistentId"));
     }
 
     @Test


### PR DESCRIPTION
Backend:
getOrganizationById now returns the Organization instead of the DTO.
Simplified the updateOrganizationFromDTO method.
Added a constructor in the Organization record to create an organization from the DTO. Related methods in the service were updated.
Organization existence is now checked by apiId instead of the name.
Removed unnecessary null check in the getAllOrganizations method.

Tests:
Updated related tests in OrganizationServiceTest